### PR TITLE
Fix number highlighting matching digits inside identifiers

### DIFF
--- a/syntaxes/KCL.tmLanguage.json
+++ b/syntaxes/KCL.tmLanguage.json
@@ -83,23 +83,31 @@
 			"patterns": [
 				{
 					"name": "constant.numeric.list.number.KCL",
-					"match": "\\-?[1-9]\\d*"
+					"match": "(?<![\\w.])\\-?(?:[1-9]\\d*|0)\\.\\d*([eE][-+]?\\d+)?"
 				},
 				{
 					"name": "constant.numeric.list.number.KCL",
-					"match": "\\-?0[xX][0-9a-fA-F]+"
+					"match": "(?<![\\w.])\\-?\\.\\d+([eE][-+]?\\d+)?"
 				},
 				{
 					"name": "constant.numeric.list.number.KCL",
-					"match": "\\-?0[oO][0-7]+"
+					"match": "(?<![\\w.])\\-?(?:[1-9]\\d*|0)[eE][-+]?\\d+\\b"
 				},
 				{
 					"name": "constant.numeric.list.number.KCL",
-					"match": "\\-?0[bB][0-1]+"
+					"match": "(?<![\\w.])\\-?0[xX][0-9a-fA-F]+\\b"
 				},
 				{
 					"name": "constant.numeric.list.number.KCL",
-					"match": "([-+]?\\d+\\.\\d*|\\.\\d+)([eE][-+]?\\d+)?|\\d+([eE][-+]?\\d+)"
+					"match": "(?<![\\w.])\\-?0[oO][0-7]+\\b"
+				},
+				{
+					"name": "constant.numeric.list.number.KCL",
+					"match": "(?<![\\w.])\\-?0[bB][0-1]+\\b"
+				},
+				{
+					"name": "constant.numeric.list.number.KCL",
+					"match": "(?<![\\w.])\\-?(?:[1-9]\\d*|0)\\b"
 				}
 			]
 		}


### PR DESCRIPTION
#### 1. Does this PR affect any open issues?(Y/N) and add issue references (e.g. "fix #123", "re #123".):

- [x] N
- [ ] Y

#### 2. What is the scope of this PR (e.g. component or file name):

`syntaxes/KCL.tmLanguage.json` (the `number` patterns)

#### 3. Provide a description of the PR(e.g. more details, effects, motivations or doc link):

- [x] Affects user behaviors
- [x] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Other

The number patterns match any run of digits with no left boundary, so a digit inside an identifier is highlighted as a number:

```kcl
k8s = "v1"                 # the 8 is colored as a number
_eu001 = {rw = "..."}      # 001 colored
DOCKER_HOST_ARM64 = "..."  # 64 colored
readonly-us-c-001          # 001 colored
```

This is most visible on github.com: VS Code masks it with language-server semantic tokens, but Linguist (which github.com uses) renders KCL with this TextMate grammar alone.

Fix:
1. Add a `(?<![\w.])` lookbehind to every number pattern so a number is only matched when not preceded by a word character or a dot (the dot also covers member access like `_us000.rw`). This matches how other grammars guard numbers: [MagicPython](https://github.com/MagicStack/MagicPython/blob/7d0f2b22a5ad8fccbd7341bc7b7a715169283044/grammars/src/MagicPython.syntax.yaml#L574).
2. Fix the float pattern, which could not match an `int.frac` literal as one token (`1.5` tokenized as `1` then `.5`). Floats now match whole, and the integer rule is ordered last so a float wins at a given position.

#### 4. Are there any breaking changes?(Y/N) and describe the breaking changes(e.g. more details, motivations or doc link):

- [x] N
- [ ] Y

#### 5. Are there test cases for these changes?(Y/N) select and add more details, references or doc links:

- [ ] Unit test
- [ ] Integration test
- [ ] Benchmark (add benchmark stats below)
- [x] Manual test (add detailed scripts or steps below)
- [ ] Other

Tokenized with the same engine github.com and VS Code use ([`vscode-textmate`](https://github.com/microsoft/vscode-textmate) + [`vscode-oniguruma`](https://github.com/microsoft/vscode-oniguruma)). Each line below shows the substrings that receive a `constant.numeric` scope.

Before:

```
k8s = "v1"             ["8"]
_eu001                 ["1"]
_us000.rw              ["000."]
readonly-us-c-001      ["1"]
DOCKER_HOST_ARM64      ["64"]
replicas = 6           ["6"]
1.5                    ["1", ".5"]
3.14                   ["3", ".14"]
1.5e3                  ["1", ".5e3"]
0xFF                   ["0xFF"]
```

After:

```
k8s = "v1"             []
_eu001                 []
_us000.rw              []
readonly-us-c-001      []
DOCKER_HOST_ARM64      []
replicas = 6           ["6"]
1.5                    ["1.5"]
3.14                   ["3.14"]
1.5e3                  ["1.5e3"]
0xFF                   ["0xFF"]
```

Identifiers with digits no longer highlight; decimal, hex, octal, binary, negative, and float literals all highlight correctly (floats now as a single whole token). Numbers inside string literals remain handled by the string rule.